### PR TITLE
ios: Add missing Markdown link reference for plugin-dev (#835)

### DIFF
--- a/www/docs/en/8.x/guide/platforms/ios/plugin.md
+++ b/www/docs/en/8.x/guide/platforms/ios/plugin.md
@@ -265,3 +265,4 @@ For JavaScript, you can attach Safari to the app running within the iOS Simulato
 [CDVPlugin.m]: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Public/CDVPlugin.m
 [ResumeEvent]: ../../../cordova/events/events.html#resume
 [PauseEvent]: ../../../cordova/events/events.html#pause
+[plugin-dev]: ../../hybrid/plugins/index.html


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] Commit message follows the format: "GH-3232: (android) Fix bug with resolving file paths", where GH-xxxx is the GitHub issue ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
